### PR TITLE
Allow setting a custom session name

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2,18 +2,20 @@
 const apiUrl = OC.generateUrl('/apps/webapppassword/create');
 const url = new URL(window.location.href);
 const targetOrigin = decodeURIComponent(url.searchParams.get('target-origin'));
+const sessionName = decodeURIComponent(url.searchParams.get('session-name'));
 
 fetch(apiUrl, {
     method: 'POST',
     headers: {
         'target-origin': targetOrigin,
+        'target-origin': sessionName,
         'requesttoken': OC.requestToken
     }
 })
     .then(response => response.json())
     .then((data) => {
         // console.log("data", data);
-        const message = {"type": "webapppassword", "loginName": data.loginName, "token": data.token, "webdavUrl": data.webdavUrl};
+        const message = { "type": "webapppassword", "loginName": data.loginName, "token": data.token, "webdavUrl": data.webdavUrl };
         window.opener.postMessage(message, targetOrigin);
         // console.log("targetOrigin", targetOrigin);
         // console.log("message", message);

--- a/lib/Config/Config.php
+++ b/lib/Config/Config.php
@@ -55,4 +55,15 @@ class Config
         $this->config->setAppValue('webapppassword', 'origins', $value);
         $this->logger->info('Origins were updated!');
     }
+
+    public function getAllowCustomName(): bool
+    {
+        return $this->config->getAppValue('webapppassword', 'allowCustomName') == 'true';
+    }
+
+    public function setAllowCustomName($value)
+    {
+        $this->config->getAppValue('webapppassword', 'allowCustomName', $value);
+        $this->logger->info('Origins were updated!');
+    }
 }

--- a/lib/Config/Config.php
+++ b/lib/Config/Config.php
@@ -58,12 +58,6 @@ class Config
 
     public function getAllowCustomName(): bool
     {
-        return $this->config->getAppValue('webapppassword', 'allowCustomName') == 'true';
-    }
-
-    public function setAllowCustomName($value)
-    {
-        $this->config->getAppValue('webapppassword', 'allowCustomName', $value);
-        $this->logger->info('Origins were updated!');
+        return $this->config->getSystemValueBool('webapppassword.allowCustomName', false);
     }
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -152,10 +152,17 @@ class PageController extends Controller
             throw new OCSForbiddenException();
         }
 
+        $name = $this->request->getParam('session-name');
+
+        if ($name === '') {
+            $name = $targetOrigin.' '.$this->request->getHeader('USER_AGENT');
+        } else {
+            'App Password: '.$name;
+        }
+
         $uid = $this->userSession->getUser()->getUID();
 //        \OC::$server->getLogger()->warning('uid: ' . var_export($uid, true));
         $targetOrigin = $this->request->getHeader('target-origin');
-        $name = $targetOrigin.' '.$this->request->getHeader('USER_AGENT');
         $token = $this->random->generate(
             72,
             ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -152,14 +152,6 @@ class PageController extends Controller
             throw new OCSForbiddenException();
         }
 
-        $name = $this->request->getParam('session-name');
-
-        if ($name === '') {
-            $name = $targetOrigin.' '.$this->request->getHeader('USER_AGENT');
-        } else {
-            'App Password: '.$name;
-        }
-
         $uid = $this->userSession->getUser()->getUID();
 //        \OC::$server->getLogger()->warning('uid: ' . var_export($uid, true));
         $targetOrigin = $this->request->getHeader('target-origin');
@@ -167,6 +159,14 @@ class PageController extends Controller
             72,
             ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS
         );
+
+        $name = $this->request->getHeader('session-name');
+
+        if ($name === '') {
+            $name = $targetOrigin.' '.$this->request->getHeader('USER_AGENT');
+        } else {
+            'App Password: '.$name;
+        }
 
         $this->tokenProvider->generateToken(
             $token,

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -28,6 +28,7 @@ class Admin implements ISettings
     {
         $parameters = [
             'origins' => $this->config->getOrigins(),
+            'allowCustomName' => $this->config->getAllowCustomName(),
         ];
 
         return new TemplateResponse('webapppassword', 'admin', $parameters);


### PR DESCRIPTION
An idea of what I mean in #45

This is a draft as I have not tested it, I don't see why it wouldn't work, but just to be sure.

Thid PR includes adding a way for a client to indicate how their should be named. This behavior is only enabled if the `allowCustomName` config is set to `true`. I did not add to the configuration page so the config would have to be set in the `config.php` file.