### PR TITLE
treefmt: don't override cs-fixer config file via CLI args

### DIFF
--- a/treefmt.toml
+++ b/treefmt.toml
@@ -33,8 +33,6 @@ includes = ["*.nix"]
 
 [formatter.php-cs-fixer]
 command = "php-cs-fixer"
-excludes = ["config/bundles.php"]
-includes = ["*.php"]
 options = ["fix", "--config", "./.php-cs-fixer.dist.php"]
 
 [formatter.shfmt]


### PR DESCRIPTION
It would try to check vendor/ and OOM due to the size there since that wasn't excluded.