### PR TITLE
Refactor Share api controller to automatically detect the parameters needed for the parent constructor call

### DIFF
--- a/lib/Controller/AccessControl.php
+++ b/lib/Controller/AccessControl.php
@@ -9,17 +9,15 @@ namespace OCA\WebAppPassword\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
-use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\AppFramework\OCS\OCSBadRequestException;
 
 trait AccessControl {
 	/**
 	 * Checks the origin of a request and modifies response.
 	 *
-	 * @throws NotFoundException
-	 * @throws OCSBadRequestException
 	 * @throws OCSException
 	 * @throws OCSForbiddenException
-	 * @throws OCSNotFoundException
+	 * @throws OCSBadRequestException
 	 * @throws InvalidPathException
 	 *
 	 * @suppress PhanUndeclaredClassMethod
@@ -28,12 +26,12 @@ trait AccessControl {
 	): DataResponse {
 		$origins_allowed = $this->getOriginList();
 		if (in_array('access-control-allow-origin', $response->getHeaders(), true)) {
-			throw new OCSNotFoundException($this->l->t('Could not create share'));
+			throw new OCSBadRequestException($this->l->t('Could not create share'));
 		}
 
 		$origin = $this->request->getHeader('origin');
 		if (empty($origin) || !in_array($origin, $origins_allowed, true)) {
-			throw new OCSNotFoundException($this->l->t('Could not create share'));
+			throw new OCSBadRequestException($this->l->t('Could not create share'));
 		}
 
 		$response->addHeader('access-control-allow-origin', $origin);
@@ -86,7 +84,6 @@ trait AccessControl {
 	 * @throws OCSBadRequestException
 	 * @throws OCSException
 	 * @throws OCSForbiddenException
-	 * @throws OCSNotFoundException
 	 * @throws InvalidPathException
 	 *
 	 * @suppress PhanUndeclaredClassMethod
@@ -95,12 +92,12 @@ trait AccessControl {
 	): FileDisplayResponse|DataResponse {
 		$origins_allowed = $this->getPreviewOriginList();
 		if (in_array('access-control-allow-origin', $response->getHeaders(), true)) {
-			return new DataResponse([], Http::STATUS_NOT_FOUND);
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 		$origin = $this->request->getHeader('origin');
 		if (empty($origin) || !in_array($origin, $origins_allowed, true)) {
-			return new DataResponse([], Http::STATUS_NOT_FOUND);
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 		$response->addHeader('access-control-allow-origin', $origin);

--- a/lib/Controller/ShareAPIController.php
+++ b/lib/Controller/ShareAPIController.php
@@ -7,77 +7,41 @@ declare(strict_types=1);
 namespace OCA\WebAppPassword\Controller;
 
 use OCA\Files_Sharing\Controller\ShareAPIController as FilesSharingShareAPIController;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\Files\InvalidPathException;
-use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
-use OCP\IDateTimeZone;
-use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\IPreview;
 use OCP\IRequest;
 use OCP\IServerContainer;
-use OCP\IURLGenerator;
-use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\Lock\LockedException;
-use OCP\Mail\IMailer;
-use OCP\Share\IManager;
-use OCP\Share\IProviderFactory;
-use OCP\UserStatus\IManager as IUserStatusManager;
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
+
+use ReflectionNamedType;
+use ReflectionParameter;
 
 class ShareAPIController extends FilesSharingShareAPIController {
 	use AccessControl;
 
+	private $files_sharing_controller;
+
+
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		private IManager $shareManager,
-		private IGroupManager $groupManager,
-		private IUserManager $userManager,
-		private IRootFolder $rootFolder,
-		private IURLGenerator $urlGenerator,
 		private IL10N $l,
 		private IConfig $config,
-		private IAppManager $appManager,
 		private IServerContainer $serverContainerOld,
 		private ContainerInterface $serverContainer,
-		private IUserStatusManager $userStatusManager,
-		private IPreview $previewManager,
-		private IDateTimeZone $dateTimeZone,
-		private IProviderFactory $factory,
-		private IMailer $mailer,
-		private LoggerInterface $logger,
-		IUserSession $userSession,
 	) {
-		// In an options request, $user will be null, as there is no Auth header to get data from.
-		$user = $userSession->getUser();
-
-		// Enforce $uid to be a string under all circumstances, because Nextcloud's own ShareApiController
-		// will break if it is null, even if it is allowed by its constructor. Passing an empty string is fine.
-		$uid = $user ? $user->getUID() ?? '' : '';
-
-		// Call the constructor.
-		// The parameter order is different between versions, this has to be accounted for.
-		// Version string is identical for 27.1.10.1 and 27.1.10.2.
-		$version = $this->config->getSystemValue('version', '0.0.0');
-		$intVersion = array_map('intval', explode('.', $version));
-
-		if ($intVersion[0] > 29) {
-			parent::__construct($AppName, $request, $shareManager, $groupManager, $userManager, $rootFolder, $urlGenerator, $l, $config, $appManager, $serverContainer, $userStatusManager, $previewManager, $dateTimeZone, $logger, $factory, $mailer, $uid);
-		} elseif ($intVersion[0] == 27 and $intVersion[1] == 1 and $intVersion[2] == 10) {
-			parent::__construct($AppName, $request, $shareManager, $groupManager, $userManager, $rootFolder, $urlGenerator, $uid, $l, $config, $appManager, $serverContainerOld, $userStatusManager, $previewManager, $dateTimeZone);
-		} else {
-			parent::__construct($AppName, $request, $shareManager, $groupManager, $userManager, $rootFolder, $urlGenerator, $l, $config, $appManager, $serverContainer, $userStatusManager, $previewManager, $dateTimeZone, $logger, $uid);
-		}
+		$this->files_sharing_controller = $serverContainer->resolve(parent::class);
+		$parent_constructor_method = new \ReflectionMethod(parent::class, '__construct');
+		$parent_constructor_params = $this->buildClassConstructorParameters($parent_constructor_method);
+		parent::__construct(...$parent_constructor_params);
 	}
 
 	/**
@@ -170,7 +134,8 @@ class ShareAPIController extends FilesSharingShareAPIController {
 	 * @throws OCSNotFoundException
 	 */
 	public function getShare(string $id, bool $include_tags = false): DataResponse {
-		$response = parent::getShare(...func_get_args());
+		$this->files_sharing_controller->getShare(...func_get_args());
+		//		$response = parent::getShare(...func_get_args());
 
 		return $this->checkOrigin($response);
 	}
@@ -276,5 +241,71 @@ class ShareAPIController extends FilesSharingShareAPIController {
 		$response = parent::deleteShare(...func_get_args());
 
 		return $this->checkOrigin($response);
+	}
+
+	/**
+	 * Fetch of constructor parameters as in AppFramework/Utility/SimpleContainer.php
+	 *
+	 * @param ReflectionMethod $constructor
+	 *   The constructor method
+	 *
+	 * @return array
+	 *   With the parameters needed to call the constructor.
+	 */
+	private function buildClassConstructorParameters(\ReflectionMethod $constructor): array {
+		// The parameter order is different between versions, this has to be accounted for.
+		// Version string is identical for 27.1.10.1 and 27.1.10.2.
+		$version = $this->config->getSystemValue('version', '0.0.0');
+		$intVersion = array_map('intval', explode('.', $version));
+
+		return array_map(function (ReflectionParameter $parameter) {
+
+			$parameterType = $parameter->getType();
+
+			$resolveName = $parameter->getName();
+
+			// try to find out if it is a class or a simple parameter
+			if ($parameterType !== null && ($parameterType instanceof ReflectionNamedType) && !$parameterType->isBuiltin()) {
+				$resolveName = $parameterType->getName();
+			}
+
+			try {
+				$builtIn = $parameterType !== null && ($parameterType instanceof ReflectionNamedType)
+							&& $parameterType->isBuiltin();
+				if ($intVersion[0] == 27 and $intVersion[1] == 1 and $intVersion[2] == 10) {
+					return $this->serverContainerOld->query($resolveName, !$builtIn);
+				} else {
+					return $this->serverContainer->query($resolveName, !$builtIn);
+				}
+			} catch (ContainerExceptionInterface $e) {
+				// Service not found, use the default value when available
+				if ($parameter->isDefaultValueAvailable()) {
+					return $parameter->getDefaultValue();
+				}
+
+				if ($parameterType !== null && ($parameterType instanceof ReflectionNamedType) && !$parameterType->isBuiltin()) {
+					$resolveName = $parameter->getName();
+					try {
+						if ($intVersion[0] == 27 and $intVersion[1] == 1 and $intVersion[2] == 10) {
+							return $this->serverContainerOld->query($resolveName);
+						} else {
+							return $this->serverContainer->query($resolveName);
+						}
+
+						return $this->serverContainer->query($resolveName);
+					} catch (ContainerExceptionInterface $e2) {
+						// Pass null if typed and nullable
+						if ($parameter->allowsNull() && ($parameterType instanceof ReflectionNamedType)) {
+							return null;
+						}
+
+						// don't lose the error we got while trying to query by type
+						throw new QueryException($e->getMessage(), (int)$e->getCode(), $e);
+					}
+				}
+
+				throw $e;
+			}
+		}, $constructor->getParameters());
 	}
 }


### PR DESCRIPTION
This way, we don't need to check every version if there are changes in parameters, as they are automatically added from reflectionclass from parent.
The  method is picked from https://github.com/nextcloud/server/blob/master/lib/private/AppFramework/Utility/SimpleContainer.php#L76C52-L76C68 , but taking in account that for specific version it is needed to use a deprecated container.

Please test it so it can be improved/merged.