### PR TITLE
Add Autodiscovery of the shareapicontroller parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,8 @@ jobs:
         run: |
           composer global require phpunit/phpunit 
           cd ${{ github.workspace }}/nextcloud
+          php -v; php -i;
+          php apps/webapppassword/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
           phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
 
   #    - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           #php /usr/local/bin/composer run phpstan || result=1
           #php /usr/local/bin/composer run psalm || result=1
           #exit $result
-        if: ${{ matrix.php-versions == '7.4' }}
+  #      if: ${{ matrix.php-versions == '7.4' }}
   #    - name: Run tests
   #      working-directory: nextcloud/apps/webapppassword
   #      run: composer global require phpunit/phpunit && phpunit -c phpunit.coverage.xml --coverage-clover build/logs/clover.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.0", "8.1", "8.2"]
-        nextcloud-versions:
-          ["stable27", "stable28", "stable29", "stable30", "stable31"]
+        php-versions: ["8.0", "8.1", "8.2", "8.3"]
+        nextcloud-versions: ["stable28", "stable29", "stable30", "stable31"]
         include:
           - php-versions: 8.2
             nextcloud-versions: stable26

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,8 @@ jobs:
           composer global require phpunit/phpunit 
           cd ${{ github.workspace }}/nextcloud
           php -v; php -i;
-          php $(which phpunit)-c phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
-          php $(which phpunit)-c tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
+          php $(which phpunit) -c phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
+          php $(which phpunit) -c tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
           phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
 
   #    - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ["8.0", "8.1", "8.2", "8.3"]
-        nextcloud-versions: ["stable28", "stable29", "stable30", "stable31"]
+        nextcloud-versions: ["stable28", "stable29", "stable30", "stable31", "stable32"]
         exclude:
           - php-versions: 8.0
             nextcloud-versions: stable31

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           cd nextcloud
           php -S localhost:8080 &
           cd apps/webapppassword
-          php /usr/local/bin/composer require --dev christophwurst/nextcloud:dev-${{ matrix.nextcloud-versions }}
+          php /usr/local/bin/composer require --dev nextcloud/ocp:dev-${{ matrix.nextcloud-versions }}
           make test
           php /usr/local/bin/composer install
           #result=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,6 @@ jobs:
         run: |
           composer global require phpunit/phpunit 
           cd ${{ github.workspace }}/nextcloud
-          php -v; php -i;
-          php $(which phpunit) -c apps/webapppassword/phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
-          php $(which phpunit) -c tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
           phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
 
   #    - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         nextcloud-versions: ["stable28", "stable29", "stable30", "stable31", "stable32"]
         exclude:
           - php-versions: 8.0
+            nextcloud-versions: stable32
+          - php-versions: 8.0
             nextcloud-versions: stable31
           - php-versions: 8.0
             nextcloud-versions: stable30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,6 @@ jobs:
       matrix:
         php-versions: ["8.0", "8.1", "8.2", "8.3"]
         nextcloud-versions: ["stable28", "stable29", "stable30", "stable31"]
-        include:
-          - php-versions: 8.2
-            nextcloud-versions: stable26
-          - php-versions: 8.2
-            nextcloud-versions: stable25
-          - php-versions: 8.0
-            nextcloud-versions: stable24
-          - php-versions: 8.0
-            nextcloud-versions: stable23
-          - php-versions: 8.0
-            nextcloud-versions: stable22
         exclude:
           - php-versions: 8.0
             nextcloud-versions: stable31

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           composer global require phpunit/phpunit 
           cd ${{ github.workspace }}/nextcloud
           php -v; php -i;
-          php $(which phpunit) -c phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
+          php $(which phpunit) -c apps/webapppassword/phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
           php $(which phpunit) -c tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
           phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ["8.0", "8.1", "8.2", "8.3"]
-        nextcloud-versions: ["stable28", "stable29", "stable30", "stable31", "stable32"]
+        nextcloud-versions:
+          ["stable28", "stable29", "stable30", "stable31", "stable32"]
         exclude:
           - php-versions: 8.0
             nextcloud-versions: stable32

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,13 @@ jobs:
           #php /usr/local/bin/composer run phpstan || result=1
           #php /usr/local/bin/composer run psalm || result=1
           #exit $result
-  #      if: ${{ matrix.php-versions == '7.4' }}
+        if: ${{ matrix.php-versions == '7.4' }}
+      - name: Run endpoints tests
+        run: |
+          composer global require phpunit/phpunit 
+          cd ${{ github.workspace }}/nextcloud
+          phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/SShareAPIControllerTest.php
+
   #    - name: Run tests
   #      working-directory: nextcloud/apps/webapppassword
   #      run: composer global require phpunit/phpunit && phpunit -c phpunit.coverage.xml --coverage-clover build/logs/clover.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           cd nextcloud
           php -S localhost:8080 &
           cd apps/webapppassword
-          php /usr/local/bin/composer require --dev nextcloud/ocp:dev-${{ matrix.nextcloud-versions }}
+          php /usr/local/bin/composer require --dev nextcloud/ocp:dev-${{ matrix.nextcloud-versions }} -W
           make test
           php /usr/local/bin/composer install
           #result=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,8 @@ jobs:
           composer global require phpunit/phpunit 
           cd ${{ github.workspace }}/nextcloud
           php -v; php -i;
-          php apps/webapppassword/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
+          php $(which phpunit)-c phpunit.integration.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
+          php $(which phpunit)-c tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
           phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
 
   #    - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           composer global require phpunit/phpunit 
           cd ${{ github.workspace }}/nextcloud
-          phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/SShareAPIControllerTest.php
+          phpunit --configuration tests/phpunit-autotest.xml apps/webapppassword/tests/Unit/Controller/ShareAPIControllerTest.php
 
   #    - name: Run tests
   #      working-directory: nextcloud/apps/webapppassword

--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,8 @@ appstore:
 
 .PHONY: test
 test: composer
-	php $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.xml
-	php $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml
+	php7.4 $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.xml
+	php7.4 $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml
 
 .PHONY: term
 term:

--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,8 @@ appstore:
 
 .PHONY: test
 test: composer
-	php7.4 $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.xml
-	php7.4 $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml
+	php $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.xml
+	php $(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml
 
 .PHONY: term
 term:

--- a/lib/Controller/ShareAPIController.php
+++ b/lib/Controller/ShareAPIController.php
@@ -45,7 +45,7 @@ class ShareAPIController extends FilesSharingShareAPIController {
 		// set the Appname parameter as it cannot come from reflection (will inject string class)
 		$parent_constructor_params[0] = $AppName;
 		// reset the userid parameter as it cannot come from reflection (will inject string class too)
-		$parent_constructor_params[array_key_last($parent_constructor_params)] = $userId;
+		$parent_constructor_params[array_key_last($parent_constructor_params)] = $userId ?? '';
 		parent::__construct(...$parent_constructor_params);
 	}
 

--- a/lib/Controller/ShareAPIController.php
+++ b/lib/Controller/ShareAPIController.php
@@ -248,7 +248,7 @@ class ShareAPIController extends FilesSharingShareAPIController {
 
 	private function buildClassConstructorParameters(\ReflectionMethod $constructor): array {
 
-		$constructor_params = array_map(function (ReflectionParameter $parameter) use ($intVersion) {
+		$constructor_params = array_map(function (ReflectionParameter $parameter) {
 
 			$parameterType = $parameter->getType();
 

--- a/lib/Controller/ShareAPIController.php
+++ b/lib/Controller/ShareAPIController.php
@@ -35,6 +35,7 @@ class ShareAPIController extends FilesSharingShareAPIController {
 		private IL10N $l,
 		private IConfig $config,
 		private ContainerInterface $serverContainer,
+		?string $userId = null
 	) {
 		$this->files_sharing_controller = $this->serverContainer->get(parent::class);
 
@@ -43,8 +44,8 @@ class ShareAPIController extends FilesSharingShareAPIController {
 		$parent_constructor_params = $this->buildClassConstructorParameters($parent_constructor_method);
 		// set the Appname parameter as it cannot come from reflection (will inject string class)
 		$parent_constructor_params[0] = $AppName;
-		// unset the userid parameter as it cannot come from reflection (will inject string class too)
-		$parent_constructor_params[array_key_last($parent_constructor_params)] = "";
+		// reset the userid parameter as it cannot come from reflection (will inject string class too)
+		$parent_constructor_params[array_key_last($parent_constructor_params)] = $userId;
 		parent::__construct(...$parent_constructor_params);
 	}
 

--- a/lib/Controller/ShareAPIController.php
+++ b/lib/Controller/ShareAPIController.php
@@ -12,12 +12,14 @@ use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\AppFramework\QueryException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Lock\LockedException;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 
 use ReflectionNamedType;

--- a/tests/Unit/Controller/ShareAPIControllerTest.php
+++ b/tests/Unit/Controller/ShareAPIControllerTest.php
@@ -79,8 +79,9 @@ class ShareAPIControllerTest extends TestCase {
 		$this->filesharingParamMocks = [];
 		$reflected_sharing = new \ReflectionMethod(FilesSharingShareAPIController::class,'__construct')->getParameters();
 		foreach ($reflected_sharing as $param) {
-			$param_t = $param->getType()->getName();
-			if (!$param->getType()->isBuiltin()) {
+			$type = $param->getType();
+			if ($type && !$type->isBuiltin()) {
+				$param_t = $type->getName();
 				$this->filesharingParamMocks[$param_t] = $this->createMock($param_t);
 			}
 		}

--- a/tests/Unit/Controller/ShareAPIControllerTest.php
+++ b/tests/Unit/Controller/ShareAPIControllerTest.php
@@ -53,7 +53,7 @@ class ShareAPIControllerTest extends TestCase {
 		/*
 			* We collect the reflected constructor parameters from (files
 			* sharing share api controller  to be mocked later. As
-			* shareapicontroller will need these when dinamically adding
+			* shareapicontroller will need these when dynamically adding
 			* parameters to build it from reflected.
 			*/
 		$this->filesharingParamMocks = [];

--- a/tests/Unit/Controller/ShareAPIControllerTest.php
+++ b/tests/Unit/Controller/ShareAPIControllerTest.php
@@ -77,6 +77,9 @@ class ShareAPIControllerTest extends TestCase {
 			* parameters to build it from reflected.
 			*/
 		$this->filesharingParamMocks = [];
+		$reflected_sharing = new \ReflectionMethod(FilesSharingShareAPIController::class,'__construct');
+		print_r($reflected_sharing);
+		print_r(get_class_methods($reflected_sharing));
 		$reflected_sharing = new \ReflectionMethod(FilesSharingShareAPIController::class,'__construct')->getParameters();
 		foreach ($reflected_sharing as $param) {
 			$param_t = $param->getType()->getName();

--- a/tests/Unit/Controller/ShareAPIControllerTest.php
+++ b/tests/Unit/Controller/ShareAPIControllerTest.php
@@ -77,9 +77,6 @@ class ShareAPIControllerTest extends TestCase {
 			* parameters to build it from reflected.
 			*/
 		$this->filesharingParamMocks = [];
-		$reflected_sharing = new \ReflectionMethod(FilesSharingShareAPIController::class,'__construct');
-		print_r($reflected_sharing);
-		print_r(get_class_methods($reflected_sharing));
 		$reflected_sharing = new \ReflectionMethod(FilesSharingShareAPIController::class,'__construct')->getParameters();
 		foreach ($reflected_sharing as $param) {
 			$param_t = $param->getType()->getName();

--- a/tests/Unit/Controller/ShareAPIControllerTest.php
+++ b/tests/Unit/Controller/ShareAPIControllerTest.php
@@ -1,45 +1,25 @@
 <?php
+
+declare(strict_types=1);
 // SPDX-FileCopyrightText: Aleix Quintana Alsius <kinta@communia.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\WebAppPassword\Tests\Unit\Controller;
 
-use OCA\WebAppPassword\AppInfo\Application;
-use OCA\WebAppPassword\Controller\ShareAPIController;
 use OCA\Files_Sharing\Controller\ShareAPIController as FilesSharingShareAPIController;
-use OCP\App\IAppManager;
-use OCP\AppFramework\Http\DataResponse;
-use OCP\AppFramework\OCS\OCSBadRequestException;
-use OCP\AppFramework\OCS\OCSException;
-use OCP\AppFramework\OCS\OCSNotFoundException;
-use OCP\Constants;
+use OCA\WebAppPassword\Controller\ShareAPIController;
 use OCP\Files\File;
 use OCP\Files\Folder;
-use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
-use OCP\Files\NotFoundException;
 use OCP\Files\Storage;
-use OCP\Files\Storage\IStorage;
 use OCP\IConfig;
-use OCP\IDateTimeZone;
-use OCP\IGroup;
-use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\IPreview;
 use OCP\IRequest;
-use OCP\IServerContainer;
-use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\IUserManager;
-use OCP\Lock\LockedException;
-use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\IAttributes as IShareAttributes;
-use OCP\Share\IManager;
 use OCP\Share\IShare;
-use OCP\UserStatus\IManager as IUserStatusManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 /**
@@ -49,7 +29,7 @@ use Test\TestCase;
  * @group DB
  */
 class ShareAPIControllerTest extends TestCase {
-    private string $appName = 'webapppassword';
+	private string $appName = 'webapppassword';
 	private ShareAPIController  $ocs;
 
 	private IRequest|MockObject $request;
@@ -77,7 +57,8 @@ class ShareAPIControllerTest extends TestCase {
 			* parameters to build it from reflected.
 			*/
 		$this->filesharingParamMocks = [];
-		$reflected_sharing = new \ReflectionMethod(FilesSharingShareAPIController::class,'__construct')->getParameters();
+		$reflected_constructor = new \ReflectionMethod(FilesSharingShareAPIController::class, '__construct');
+		$reflected_sharing = $reflected_constructor->getParameters();
 		foreach ($reflected_sharing as $param) {
 			$type = $param->getType();
 			if ($type && !$type->isBuiltin()) {
@@ -387,76 +368,76 @@ class ShareAPIControllerTest extends TestCase {
 	 *
 	 * FIXME: WIP testGetShare
 	 *
-	public function testGetShare(IShare $share, array $result): void {
-
-		// @var ShareAPIController&MockObject $ocs
-		$ocs = $this->getMockBuilder(ShareAPIController::class)
-				->setConstructorArgs([
-					$this->appName,
-					$this->request,
-					$this->l,
-					$this->config,
-					$this->serverContainer,
-				])//->setMethods(['canAccessShare'])
-				->getMock();
-
-		$this->filesharingParamMocks['OCP\Share\IManager']
-			->expects($this->any())
-			->method('getsharebyid')
-			->with($share->getfullid(), 'currentuser')
-			->willreturn($share);
-
-		$userFolder = $this->getMockBuilder('OCP\Files\Folder')->getMock();
-		$userFolder
-			->method('getRelativePath')
-			->willReturnArgument(0);
-
-		$userFolder->method('getById')
-			->with($share->getNodeId())
-			->willReturn([$share->getNode()]);
-
-		$this->filesharingParamMocks['OCP\Files\IRootFolder']->method('getUserFolder')
-			->with($this->currentUser)
-			->willReturn($userFolder);
-
-		$this->filesharingParamMocks['OCP\IURLGenerator']
-			->method('linkToRouteAbsolute')
-			->willReturn('url');
-
-		$initiator = $this->getMockBuilder(IUser::class)->getMock();
-		$initiator->method('getUID')->willReturn('initiatorId');
-		$initiator->method('getDisplayName')->willReturn('initiatorDisplay');
-
-		$owner = $this->getMockBuilder(IUser::class)->getMock();
-		$owner->method('getUID')->willReturn('ownerId');
-		$owner->method('getDisplayName')->willReturn('ownerDisplay');
-
-		$user = $this->getMockBuilder(IUser::class)->getMock();
-		$user->method('getUID')->willReturn('userId');
-		$user->method('getDisplayName')->willReturn('userDisplay');
-		$user->method('getSystemEMailAddress')->willReturn('userId@example.com');
-
-		$group = $this->getMockBuilder('OCP\IGroup')->getMock();
-		$group->method('getGID')->willReturn('groupId');
-
-		$this->filesharingParamMocks['OCP\IUserManager']
-		->method('get')->willReturnMap([
-			['userId', $user],
-			['initiatorId', $initiator],
-			['ownerId', $owner],
-		]);
-
-		$this->filesharingParamMocks['OCP\IGroupManager']
-		->method('get')->willReturnMap([
-			['group', $group],
-		]);
-		$this->filesharingParamMocks['OCP\IDateTimeZone']->method('getTimezone')->willReturn(new \DateTimeZone('UTC'));
-
-		$d = $ocs->getShare($share->getId())->getData()[0];
-
-		$this->assertEquals($result, $ocs->getShare($share->getId())->getData()[0]);
-	}
-*/
+	 * public function testGetShare(IShare $share, array $result): void {
+	 *
+	 * // @var ShareAPIController&MockObject $ocs
+	 * $ocs = $this->getMockBuilder(ShareAPIController::class)
+	 * ->setConstructorArgs([
+	 * $this->appName,
+	 * $this->request,
+	 * $this->l,
+	 * $this->config,
+	 * $this->serverContainer,
+	 * ])//->setMethods(['canAccessShare'])
+	 * ->getMock();
+	 *
+	 * $this->filesharingParamMocks['OCP\Share\IManager']
+	 * ->expects($this->any())
+	 * ->method('getsharebyid')
+	 * ->with($share->getfullid(), 'currentuser')
+	 * ->willreturn($share);
+	 *
+	 * $userFolder = $this->getMockBuilder('OCP\Files\Folder')->getMock();
+	 * $userFolder
+	 * ->method('getRelativePath')
+	 * ->willReturnArgument(0);
+	 *
+	 * $userFolder->method('getById')
+	 * ->with($share->getNodeId())
+	 * ->willReturn([$share->getNode()]);
+	 *
+	 * $this->filesharingParamMocks['OCP\Files\IRootFolder']->method('getUserFolder')
+	 * ->with($this->currentUser)
+	 * ->willReturn($userFolder);
+	 *
+	 * $this->filesharingParamMocks['OCP\IURLGenerator']
+	 * ->method('linkToRouteAbsolute')
+	 * ->willReturn('url');
+	 *
+	 * $initiator = $this->getMockBuilder(IUser::class)->getMock();
+	 * $initiator->method('getUID')->willReturn('initiatorId');
+	 * $initiator->method('getDisplayName')->willReturn('initiatorDisplay');
+	 *
+	 * $owner = $this->getMockBuilder(IUser::class)->getMock();
+	 * $owner->method('getUID')->willReturn('ownerId');
+	 * $owner->method('getDisplayName')->willReturn('ownerDisplay');
+	 *
+	 * $user = $this->getMockBuilder(IUser::class)->getMock();
+	 * $user->method('getUID')->willReturn('userId');
+	 * $user->method('getDisplayName')->willReturn('userDisplay');
+	 * $user->method('getSystemEMailAddress')->willReturn('userId@example.com');
+	 *
+	 * $group = $this->getMockBuilder('OCP\IGroup')->getMock();
+	 * $group->method('getGID')->willReturn('groupId');
+	 *
+	 * $this->filesharingParamMocks['OCP\IUserManager']
+	 * ->method('get')->willReturnMap([
+	 * ['userId', $user],
+	 * ['initiatorId', $initiator],
+	 * ['ownerId', $owner],
+	 * ]);
+	 *
+	 * $this->filesharingParamMocks['OCP\IGroupManager']
+	 * ->method('get')->willReturnMap([
+	 * ['group', $group],
+	 * ]);
+	 * $this->filesharingParamMocks['OCP\IDateTimeZone']->method('getTimezone')->willReturn(new \DateTimeZone('UTC'));
+	 *
+	 * $d = $ocs->getShare($share->getId())->getData()[0];
+	 *
+	 * $this->assertEquals($result, $ocs->getShare($share->getId())->getData()[0]);
+	 * }
+	 */
 
 
 

--- a/tests/Unit/Controller/ShareAPIControllerTest.php
+++ b/tests/Unit/Controller/ShareAPIControllerTest.php
@@ -1,0 +1,462 @@
+<?php
+// SPDX-FileCopyrightText: Aleix Quintana Alsius <kinta@communia.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\WebAppPassword\Tests\Unit\Controller;
+
+use OCA\WebAppPassword\AppInfo\Application;
+use OCA\WebAppPassword\Controller\ShareAPIController;
+use OCA\Files_Sharing\Controller\ShareAPIController as FilesSharingShareAPIController;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\AppFramework\OCS\OCSException;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\Constants;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\NotFoundException;
+use OCP\Files\Storage;
+use OCP\Files\Storage\IStorage;
+use OCP\IConfig;
+use OCP\IDateTimeZone;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IPreview;
+use OCP\IRequest;
+use OCP\IServerContainer;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Lock\LockedException;
+use OCP\Share\Exceptions\GenericShareException;
+use OCP\Share\IAttributes as IShareAttributes;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use OCP\UserStatus\IManager as IUserStatusManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+/**
+ * Class ShareAPIControllerTest
+ *
+ * @package OCA\Files_Sharing\Tests\Controller
+ * @group DB
+ */
+class ShareAPIControllerTest extends TestCase {
+    private string $appName = 'webapppassword';
+	private ShareAPIController  $ocs;
+
+	private IRequest|MockObject $request;
+	private IL10N|MockObject $l;
+	private IConfig|MockObject $config;
+	private ContainerInterface|MockObject $serverContainer;
+
+	protected function setUp(): void {
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->l = $this->createMock(IL10N::class);
+		$this->l->method('t')
+			->willReturnCallback(function ($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			});
+		$this->config = $this->createMock(IConfig::class);
+		$this->serverContainer = $this->createMock(ContainerInterface::class);
+
+		$this->filesSharingShareAPIController = $this->createMock(FilesSharingShareAPIController::class);
+
+		/*
+			* We collect the reflected constructor parameters from (files
+			* sharing share api controller  to be mocked later. As
+			* shareapicontroller will need these when dinamically adding
+			* parameters to build it from reflected.
+			*/
+		$this->filesharingParamMocks = [];
+		$reflected_sharing = new \ReflectionMethod(FilesSharingShareAPIController::class,'__construct')->getParameters();
+		foreach ($reflected_sharing as $param) {
+			$param_t = $param->getType()->getName();
+			if (!$param->getType()->isBuiltin()) {
+				$this->filesharingParamMocks[$param_t] = $this->createMock($param_t);
+			}
+		}
+		/*
+			* We tell what needs to be returned when buildconstructorparameters is called
+			* in ShareAPIController, it comes from reflected FilesSharingShareAPIController
+			* above.
+			*/
+		$this->serverContainer
+		->method('get')
+		->willReturnCallback(function ($className) {
+			return $this->filesharingParamMocks[$className] ?? null;
+		});
+		$this->ocs = new ShareAPIController(
+			$this->appName,
+			$this->request,
+			$this->l,
+			$this->config,
+			$this->serverContainer,
+		);
+	}
+
+	public function testParentParams() {
+		$this->assertEqualsCanonicalizing(get_class_methods(FilesSharingShareAPIController::class), get_class_methods($this->ocs));
+	}
+
+	/*
+	 * FIXME: WIP testGetGetShare
+	private function mockShareAttributes() {
+		$formattedShareAttributes = [
+			[
+				'scope' => 'permissions',
+				'key' => 'download',
+				'enabled' => true
+			]
+		];
+
+		$shareAttributes = $this->createMock(IShareAttributes::class);
+		$shareAttributes->method('toArray')->willReturn($formattedShareAttributes);
+		$shareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(true);
+
+		// send both IShare attributes class and expected json string
+		return [$shareAttributes, \json_encode($formattedShareAttributes)];
+	}
+
+	public function createShare($id, $shareType, $sharedWith, $sharedBy, $shareOwner, $path, $permissions,
+		$shareTime, $expiration, $parent, $target, $mail_send, $note = '', $token = null,
+		$password = null, $label = '', $attributes = null) {
+		$share = $this->getMockBuilder(IShare::class)->getMock();
+		$share->method('getId')->willReturn($id);
+		$share->method('getShareType')->willReturn($shareType);
+		$share->method('getSharedWith')->willReturn($sharedWith);
+		$share->method('getSharedBy')->willReturn($sharedBy);
+		$share->method('getShareOwner')->willReturn($shareOwner);
+		$share->method('getNode')->willReturn($path);
+		$share->method('getPermissions')->willReturn($permissions);
+		$share->method('getNote')->willReturn($note);
+		$share->method('getLabel')->willReturn($label);
+		$share->method('getAttributes')->willReturn($attributes);
+		$time = new \DateTime();
+		$time->setTimestamp($shareTime);
+		$share->method('getShareTime')->willReturn($time);
+		$share->method('getExpirationDate')->willReturn($expiration);
+		$share->method('getTarget')->willReturn($target);
+		$share->method('getMailSend')->willReturn($mail_send);
+		$share->method('getToken')->willReturn($token);
+		$share->method('getPassword')->willReturn($password);
+
+		if ($shareType === IShare::TYPE_USER ||
+			$shareType === IShare::TYPE_GROUP ||
+			$shareType === IShare::TYPE_LINK) {
+			$share->method('getFullId')->willReturn('ocinternal:'.$id);
+		}
+
+		return $share;
+	}
+
+	public function dataGetShare() {
+		$data = [];
+
+		$cache = $this->getMockBuilder('OC\Files\Cache\Cache')
+			->disableOriginalConstructor()
+			->getMock();
+		$cache->method('getNumericStorageId')->willReturn(101);
+
+		$storage = $this->getMockBuilder(Storage::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$storage->method('getId')->willReturn('STORAGE');
+		$storage->method('getCache')->willReturn($cache);
+
+		$parentFolder = $this->getMockBuilder('OCP\Files\Folder')->getMock();
+		$parentFolder->method('getId')->willReturn(3);
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->method('getMountType')->willReturn('');
+
+		$file = $this->getMockBuilder('OCP\Files\File')->getMock();
+		$file->method('getId')->willReturn(1);
+		$file->method('getPath')->willReturn('file');
+		$file->method('getStorage')->willReturn($storage);
+		$file->method('getParent')->willReturn($parentFolder);
+		$file->method('getSize')->willReturn(123465);
+		$file->method('getMTime')->willReturn(1234567890);
+		$file->method('getMimeType')->willReturn('myMimeType');
+		$file->method('getMountPoint')->willReturn($mountPoint);
+
+		$folder = $this->getMockBuilder('OCP\Files\Folder')->getMock();
+		$folder->method('getId')->willReturn(2);
+		$folder->method('getPath')->willReturn('folder');
+		$folder->method('getStorage')->willReturn($storage);
+		$folder->method('getParent')->willReturn($parentFolder);
+		$folder->method('getSize')->willReturn(123465);
+		$folder->method('getMTime')->willReturn(1234567890);
+		$folder->method('getMimeType')->willReturn('myFolderMimeType');
+		$folder->method('getMountPoint')->willReturn($mountPoint);
+
+		[$shareAttributes, $shareAttributesReturnJson] = $this->mockShareAttributes();
+
+		// File shared with user
+		$share = $this->createShare(
+			100,
+			IShare::TYPE_USER,
+			'userId',
+			'initiatorId',
+			'ownerId',
+			$file,
+			4,
+			5,
+			null,
+			6,
+			'target',
+			0,
+			'personal note',
+			$shareAttributes,
+		);
+		$expected = [
+			'id' => 100,
+			'share_type' => IShare::TYPE_USER,
+			'share_with' => 'userId',
+			'share_with_displayname' => 'userDisplay',
+			'share_with_displayname_unique' => 'userId@example.com',
+			'uid_owner' => 'initiatorId',
+			'displayname_owner' => 'initiatorDisplay',
+			'item_type' => 'file',
+			'item_source' => 1,
+			'file_source' => 1,
+			'file_target' => 'target',
+			'file_parent' => 3,
+			'token' => null,
+			'expiration' => null,
+			'permissions' => 4,
+			'attributes' => $shareAttributesReturnJson,
+			'stime' => 5,
+			'parent' => null,
+			'storage_id' => 'STORAGE',
+			'path' => 'file',
+			'storage' => 101,
+			'mail_send' => 0,
+			'uid_file_owner' => 'ownerId',
+			'note' => 'personal note',
+			'label' => '',
+			'displayname_file_owner' => 'ownerDisplay',
+			'mimetype' => 'myMimeType',
+			'has_preview' => false,
+			'hide_download' => 0,
+			'can_edit' => false,
+			'can_delete' => false,
+			'item_size' => 123465,
+			'item_mtime' => 1234567890,
+			'attributes' => null,
+			'item_permissions' => 4,
+			'is-mount-root' => false,
+			'mount-type' => '',
+		];
+		$data[] = [$share, $expected];
+
+		// Folder shared with group
+		$share = $this->createShare(
+			101,
+			IShare::TYPE_GROUP,
+			'groupId',
+			'initiatorId',
+			'ownerId',
+			$folder,
+			4,
+			5,
+			null,
+			6,
+			'target',
+			0,
+			'personal note',
+			$shareAttributes,
+		);
+		$expected = [
+			'id' => 101,
+			'share_type' => IShare::TYPE_GROUP,
+			'share_with' => 'groupId',
+			'share_with_displayname' => 'groupId',
+			'uid_owner' => 'initiatorId',
+			'displayname_owner' => 'initiatorDisplay',
+			'item_type' => 'folder',
+			'item_source' => 2,
+			'file_source' => 2,
+			'file_target' => 'target',
+			'file_parent' => 3,
+			'token' => null,
+			'expiration' => null,
+			'permissions' => 4,
+			'attributes' => $shareAttributesReturnJson,
+			'stime' => 5,
+			'parent' => null,
+			'storage_id' => 'STORAGE',
+			'path' => 'folder',
+			'storage' => 101,
+			'mail_send' => 0,
+			'uid_file_owner' => 'ownerId',
+			'note' => 'personal note',
+			'label' => '',
+			'displayname_file_owner' => 'ownerDisplay',
+			'mimetype' => 'myFolderMimeType',
+			'has_preview' => false,
+			'hide_download' => 0,
+			'can_edit' => false,
+			'can_delete' => false,
+			'item_size' => 123465,
+			'item_mtime' => 1234567890,
+			'attributes' => null,
+			'item_permissions' => 4,
+			'is-mount-root' => false,
+			'mount-type' => '',
+		];
+		$data[] = [$share, $expected];
+
+		// File shared by link with Expire
+		$expire = \DateTime::createFromFormat('Y-m-d h:i:s', '2000-01-02 01:02:03');
+		$share = $this->createShare(
+			101,
+			IShare::TYPE_LINK,
+			null,
+			'initiatorId',
+			'ownerId',
+			$folder,
+			4,
+			5,
+			$expire,
+			6,
+			'target',
+			0,
+			'personal note',
+			'token',
+			'password',
+			'first link share'
+		);
+		$expected = [
+			'id' => 101,
+			'share_type' => IShare::TYPE_LINK,
+			'password' => 'password',
+			'share_with' => 'password',
+			'share_with_displayname' => '(Shared link)',
+			'send_password_by_talk' => false,
+			'uid_owner' => 'initiatorId',
+			'displayname_owner' => 'initiatorDisplay',
+			'item_type' => 'folder',
+			'item_source' => 2,
+			'file_source' => 2,
+			'file_target' => 'target',
+			'file_parent' => 3,
+			'token' => 'token',
+			'expiration' => '2000-01-02 00:00:00',
+			'permissions' => 4,
+			'attributes' => null,
+			'stime' => 5,
+			'parent' => null,
+			'storage_id' => 'STORAGE',
+			'path' => 'folder',
+			'storage' => 101,
+			'mail_send' => 0,
+			'url' => 'url',
+			'uid_file_owner' => 'ownerId',
+			'note' => 'personal note',
+			'label' => 'first link share',
+			'displayname_file_owner' => 'ownerDisplay',
+			'mimetype' => 'myFolderMimeType',
+			'has_preview' => false,
+			'hide_download' => 0,
+			'can_edit' => false,
+			'can_delete' => false,
+			'item_size' => 123465,
+			'item_mtime' => 1234567890,
+			'attributes' => null,
+			'item_permissions' => 4,
+			'is-mount-root' => false,
+			'mount-type' => '',
+		];
+		$data[] = [$share, $expected];
+
+		return $data;
+	}
+	*/
+
+	/**
+	 * @dataProvider dataGetShare
+	 *
+	 * FIXME: WIP testGetShare
+	 *
+	public function testGetShare(IShare $share, array $result): void {
+
+		// @var ShareAPIController&MockObject $ocs
+		$ocs = $this->getMockBuilder(ShareAPIController::class)
+				->setConstructorArgs([
+					$this->appName,
+					$this->request,
+					$this->l,
+					$this->config,
+					$this->serverContainer,
+				])//->setMethods(['canAccessShare'])
+				->getMock();
+
+		$this->filesharingParamMocks['OCP\Share\IManager']
+			->expects($this->any())
+			->method('getsharebyid')
+			->with($share->getfullid(), 'currentuser')
+			->willreturn($share);
+
+		$userFolder = $this->getMockBuilder('OCP\Files\Folder')->getMock();
+		$userFolder
+			->method('getRelativePath')
+			->willReturnArgument(0);
+
+		$userFolder->method('getById')
+			->with($share->getNodeId())
+			->willReturn([$share->getNode()]);
+
+		$this->filesharingParamMocks['OCP\Files\IRootFolder']->method('getUserFolder')
+			->with($this->currentUser)
+			->willReturn($userFolder);
+
+		$this->filesharingParamMocks['OCP\IURLGenerator']
+			->method('linkToRouteAbsolute')
+			->willReturn('url');
+
+		$initiator = $this->getMockBuilder(IUser::class)->getMock();
+		$initiator->method('getUID')->willReturn('initiatorId');
+		$initiator->method('getDisplayName')->willReturn('initiatorDisplay');
+
+		$owner = $this->getMockBuilder(IUser::class)->getMock();
+		$owner->method('getUID')->willReturn('ownerId');
+		$owner->method('getDisplayName')->willReturn('ownerDisplay');
+
+		$user = $this->getMockBuilder(IUser::class)->getMock();
+		$user->method('getUID')->willReturn('userId');
+		$user->method('getDisplayName')->willReturn('userDisplay');
+		$user->method('getSystemEMailAddress')->willReturn('userId@example.com');
+
+		$group = $this->getMockBuilder('OCP\IGroup')->getMock();
+		$group->method('getGID')->willReturn('groupId');
+
+		$this->filesharingParamMocks['OCP\IUserManager']
+		->method('get')->willReturnMap([
+			['userId', $user],
+			['initiatorId', $initiator],
+			['ownerId', $owner],
+		]);
+
+		$this->filesharingParamMocks['OCP\IGroupManager']
+		->method('get')->willReturnMap([
+			['group', $group],
+		]);
+		$this->filesharingParamMocks['OCP\IDateTimeZone']->method('getTimezone')->willReturn(new \DateTimeZone('UTC'));
+
+		$d = $ocs->getShare($share->getId())->getData()[0];
+
+		$this->assertEquals($result, $ocs->getShare($share->getId())->getData()[0]);
+	}
+*/
+
+
+
+}


### PR DESCRIPTION
This MR adds a way to autodiscover the parameters of the parent class of ShareapiApiController from files_sharing app .
It also adds a unit test that checks that parameters match between parent and child classes, eventually the unit test could be expanded to cover the return of the getShare function (by now commented in test).The test depends on new action in test.yml  ( https://github.com/aleixq/webapppassword/blob/unopiniated-constructor/.github/workflows/test.yml#L72 ).

Please check https://github.com/aleixq/webapppassword/actions/runs/18201186657 and see why it fails in some cases and let's discuss if it must be solved or not. So waiting for review to get out of draft state.  


(I hope that commits get shallowed because I had some issues and a lot of silly commits will pollute the history)